### PR TITLE
Fix documentation repository base url

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -71,7 +71,7 @@ const config: DocsThemeConfig = {
         link: 'https://github.com/l3montree-dev/devguard',
     },
     docsRepositoryBase:
-        'https://github.com/l3montree-dev/devguard-documentation',
+        'https://github.com/l3montree-dev/devguard-documentation/tree/main',
     backgroundColor: {
         dark: '12,17,23',
         light: '240,242,245',


### PR DESCRIPTION
Clicking on the "Edit this page" button leads to e.g. `https://github.com/l3montree-dev/devguard-documentation/src/pages/introduction.mdx`, but should be `https://github.com/l3montree-dev/devguard-documentation/tree/main/src/pages/introduction.mdx`.