### PR TITLE
fix: change api url for workflows to api.devguard.org

### DIFF
--- a/src/pages/feature-guides/csaf-common-security-advisory-framework.mdx
+++ b/src/pages/feature-guides/csaf-common-security-advisory-framework.mdx
@@ -25,7 +25,7 @@ After enabling CSAF reports, your organization's vulnerability data becomes acce
 ### Instance Lister
 
 On the instance level all organizations providing CSAF reports are listed:
-- Primary endpoint: `https://api.main.devguard.org/api/v1/.well-known/csaf-aggregator/aggregator.json`
+- Primary endpoint: `https://api.devguard.org/api/v1/.well-known/csaf-aggregator/aggregator.json`
 - Alternative endpoint: `https://main.devguard.org/.well-known/csaf-aggregator/aggregator.json`
 
 Your organization will be **listed publicly** as a provider in this list once you enable public access to vulnerability data.
@@ -35,7 +35,7 @@ Your organization will be **listed publicly** as a provider in this list once yo
 Each organization has a provider metadata file that lists all repositories (assets) with CSAF reports available:
 
 ```
-https://api.main.devguard.org/api/v1/organizations/{org-name}/csaf/provider-metadata.json
+https://api.devguard.org/api/v1/organizations/{org-name}/csaf/provider-metadata.json
 ```
 
 This file contains a `distributions` array listing `directory_url` your repositories (assets) that have CSAF reports enabled.
@@ -45,12 +45,12 @@ This file contains a `distributions` array listing `directory_url` your reposito
 Individual vulnerability reports for each asset are organized by year and TLP (Traffic Light Protocol) (DevGuard currently only supports TLP:WHITE) level:
 
 ```
-https://api.main.devguard.org/api/v1/organizations/{org-name}/projects/{project-name}/assets/{asset-name}/csaf/white/{year}/
+https://api.devguard.org/api/v1/organizations/{org-name}/projects/{project-name}/assets/{asset-name}/csaf/white/{year}/
 ```
 
 Each asset will have a separate CSAF report for every vulnerability that has been detected throughout its lifetime.
 
-[Example Index](https://api.main.devguard.org/api/v1/organizations/l3montree-cybersecurity/projects/devguard/assets/devguard-web/csaf/white/)
+[Example Index](https://api.devguard.org/api/v1/organizations/l3montree-cybersecurity/projects/devguard/assets/devguard-web/csaf/white/)
 of the DevGuard backend repository.
 
 ## Consuming CSAF Reports as Upstream Data
@@ -66,7 +66,7 @@ upstreams CSAF URL and PURL to one of your assets:
 
 1. **Provider Metadata URL**: The organization's CSAF provider metadata endpoint
    ```
-   https://api.main.devguard.org/api/v1/organizations/{org-name}/csaf/provider-metadata.json
+   https://api.devguard.org/api/v1/organizations/{org-name}/csaf/provider-metadata.json
    ```
 
 2. **Package URL (PURL)**: The identifier for the specific asset you want to track. You usally get that PURL from your upstream.

--- a/src/pages/feature-guides/discover-base-image-attestations.mdx
+++ b/src/pages/feature-guides/discover-base-image-attestations.mdx
@@ -89,5 +89,5 @@ devguard-scanner discover-baseimage-attestations Dockerfile
 jq '.predicate' vex > vex-document.json
 
 # Upload the extracted VEX document
-devguard-scanner vex --token xyz --apiUrl https://api.main.devguard.org/ --assetName my-org/projects/my-group/assets/my-repo vex-document.json
+devguard-scanner vex --token xyz --apiUrl https://api.devguard.org/ --assetName my-org/projects/my-group/assets/my-repo vex-document.json
 ```

--- a/src/pages/feature-guides/ingesting-upstream-information.mdx
+++ b/src/pages/feature-guides/ingesting-upstream-information.mdx
@@ -51,12 +51,12 @@ Use the DevGuard scanner CLI to upload VEX documents or SBOMs. Like the other co
         </TabsList>
         <TabsContent value="vex">
             ```bash
-            devguard-scanner vex --token xyz --apiUrl https://api.main.devguard.org/ --assetName my-org/projects/a-group/assets/my-repo vex.json
+            devguard-scanner vex --token xyz --apiUrl https://api.devguard.org/ --assetName my-org/projects/a-group/assets/my-repo vex.json
             ```
         </TabsContent>
         <TabsContent value="sbom">
             ```bash 
-            devguard-scanner sbom --token xyz --apiUrl https://api.main.devguard.org/ --assetName my-org/projects/a-group/assets/my-repo sbom.json
+            devguard-scanner sbom --token xyz --apiUrl https://api.devguard.org/ --assetName my-org/projects/a-group/assets/my-repo sbom.json
             ```
         </TabsContent>
     </Tabs>

--- a/src/pages/getting-started/setup-gitlab-integration.mdx
+++ b/src/pages/getting-started/setup-gitlab-integration.mdx
@@ -61,7 +61,7 @@ Add a name for the Integration (like Tom's Personal Access Token, or Project Acc
 
     if you are using devguard under main.devguard.org
     ```sh copy
-    https://api.main.devguard.org/api/v1/webhook/
+    https://api.devguard.org/api/v1/webhook/
     ```
     then select the events you want to trigger the webhook, it is recommended to select following events:
 

--- a/src/pages/other/github-workflows/build-image.mdx
+++ b/src/pages/other/github-workflows/build-image.mdx
@@ -5,7 +5,7 @@ import {Build} from '../../../components/texts/CICDJobs'
 The `build-image` workflow accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 | `image-destination-path`| Destination of the image.tar file | No          | `image.tar`                                      | 
@@ -26,7 +26,7 @@ jobs:
     devguard-build-image:
         uses: l3montree-dev/devguard-action/.github/workflows/build-image.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/code-risk-identification.mdx
+++ b/src/pages/other/github-workflows/code-risk-identification.mdx
@@ -7,7 +7,7 @@ The `code-risk-identification` accepts the following inputs:
 
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                           | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                           | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `sarif-file`              | Path to the sarif file to be scanned | Yes         |         `sbom.json`                               |
 | `sarif-artifact-name`              | Name of the SBOM artifact to be downloaded | No         |         `''`                               |
@@ -24,7 +24,7 @@ jobs:
     devguard-code-risk-identification:
         uses: l3montree-dev/devguard-action/.github/workflows/code-risk-identification.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
           sbom-file: "./sbom.json" 
         secrets:
@@ -63,7 +63,7 @@ jobs:
         needs: secret-scanning
         uses: l3montree-dev/devguard-action/.github/workflows/code-risk-identification.yml@feautre/sarif-sbom-upload-actions
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
           sarif-artifact-name: gitleaks-report
           sarif-file: gitleaks.sarif.json

--- a/src/pages/other/github-workflows/container-scanning.mdx
+++ b/src/pages/other/github-workflows/container-scanning.mdx
@@ -6,7 +6,7 @@ import {ContainerScanning} from '../../../components/texts/CICDJobs'
 The `container-scanning` accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 | `image-path`| Path to the OCI image to be scanned. Only necessary if the reusable workflow is not used for further processing of the built image.tar | No          | `image.tar`                                      | 
@@ -25,7 +25,7 @@ jobs:
     devguard-container-scanning:
         uses: l3montree-dev/devguard-action/.github/workflows/container-scanning.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/dependency-risk-identification.mdx
+++ b/src/pages/other/github-workflows/dependency-risk-identification.mdx
@@ -6,7 +6,7 @@ import {DependencyRiskIdentification} from '../../../components/texts/CICDJobs'
 The `dependency-risk-identification` accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                           | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                           | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `sbom-file`              | Path to the SBOM file to be scanned | Yes         |         `sbom.json`                               |
 | `sbom-artifact-name`              | Name of the SBOM artifact to be downloaded | No         |         `''`                               |
@@ -25,7 +25,7 @@ jobs:
     devguard-dependency-risk-identification:
         uses: l3montree-dev/devguard-action/.github/workflows/dependency-risk-identification.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
           sbom-file: "./sbom.json" 
         secrets:
@@ -65,7 +65,7 @@ jobs:
         needs: software-composition-analysis
         uses: l3montree-dev/devguard-action/.github/workflows/code-risk-identification.yml@feautre/sarif-sbom-upload-actions
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
           sarif-artifact-name: sbom-report
           sarif-file: sbom.json

--- a/src/pages/other/github-workflows/deploy.mdx
+++ b/src/pages/other/github-workflows/deploy.mdx
@@ -5,7 +5,7 @@ import {Deploy} from '../../../components/texts/CICDJobs'
 The `deploy` accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 | `should-deploy`|Should the deploy job run | No          | `true`                                      | 
@@ -26,7 +26,7 @@ jobs:
     devguard-deploy:
         uses: l3montree-dev/devguard-action/.github/workflows/deploy.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/full.mdx
+++ b/src/pages/other/github-workflows/full.mdx
@@ -10,7 +10,7 @@ The `deploy` step runs only if the following jobs complete successfully:
 The `full-scan` workflow accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 | `image-destination-path`| Destination of the image.tar file. Only necessary if deploy reusable workflow is not used and you would like to do further processing of the builded image.tar' | No          | `image.tar`                                      | 
@@ -31,7 +31,7 @@ jobs:
     devguard-full-scan:
         uses: l3montree-dev/devguard-action/.github/workflows/full.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/iac.mdx
+++ b/src/pages/other/github-workflows/iac.mdx
@@ -5,7 +5,7 @@ import {IAC} from '../../../components/texts/CICDJobs'
   The `iac` accept a following inputs:
   | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 
@@ -21,7 +21,7 @@ jobs:
     devguard-iac:
         uses: l3montree-dev/devguard-action/.github/workflows/iac.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/sast.mdx
+++ b/src/pages/other/github-workflows/sast.mdx
@@ -6,7 +6,7 @@ import {SAST} from '../../../components/texts/CICDJobs'
  The `sast` accept a following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 
@@ -23,7 +23,7 @@ jobs:
     devguard-sast:
         uses: l3montree-dev/devguard-action/.github/workflows/sast.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/sca.mdx
+++ b/src/pages/other/github-workflows/sca.mdx
@@ -5,7 +5,7 @@ import {SCA} from '../../../components/texts/CICDJobs'
 The `sca` accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 
@@ -21,7 +21,7 @@ jobs:
     devguard-sca:
         uses: l3montree-dev/devguard-action/.github/workflows/sca.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/secret-scanning.mdx
+++ b/src/pages/other/github-workflows/secret-scanning.mdx
@@ -9,7 +9,7 @@ import {SecretScanning} from '../../../components/texts/CICDJobs'
  The `secret-scanning` accept a following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              | 
 
@@ -26,7 +26,7 @@ jobs:
     devguard-secret-scanning:
         uses: l3montree-dev/devguard-action/.github/workflows/secret-scanning.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/github-workflows/sign.mdx
+++ b/src/pages/other/github-workflows/sign.mdx
@@ -5,7 +5,7 @@ import {Sign} from '../../../components/texts/CICDJobs'
 The `sign` accepts the following inputs:
 | Name                   | Description                                                                   | Required    | Default Value                                    | 
 |------------------------|--------------------------|-----|----------------------------------|
-| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.main.devguard.org`                 |  
+| `api-url`               | URL of the DevGuard API                                                       | No          | `https://api.devguard.org`                 |  
 | `asset-name`            | Name of the asset to be scanned                                               | Yes         |                                                 |           
 | `path`              | Path to the source code to be scanned                                         | No          | `.`                                              |                                    | 
 | `artifact-suffix`                 |   This is only needed if you are using this job multiple times in the same workflow. For example if you are scanning multiple images build from the same source with different configuration.                  | No          |                 `''`                                | 
@@ -23,7 +23,7 @@ jobs:
     devguard-sign:
         uses: l3montree-dev/devguard-action/.github/workflows/sign.yml@main
         with:
-          api-url: https://api.main.devguard.org
+          api-url: https://api.devguard.org
           asset-name: 'myOrgnaization/projects/myProject/assets/myAsset'
         secrets:
           devguard-token: ${{ secrets.DEVGUARD_TOKEN }}

--- a/src/pages/other/gitlab-components/build-image.mdx
+++ b/src/pages/other/gitlab-components/build-image.mdx
@@ -5,7 +5,7 @@ import {Build} from '../../../components/texts/CICDJobs'
 The `build-image` workflow accepts the following inputs:
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/code-risk-identification.mdx
+++ b/src/pages/other/gitlab-components/code-risk-identification.mdx
@@ -7,7 +7,7 @@ The `code-risk-identification` accepts the following inputs:
 
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/container-scanning.mdx
+++ b/src/pages/other/gitlab-components/container-scanning.mdx
@@ -6,7 +6,7 @@ import {ContainerScanning} from '../../../components/texts/CICDJobs'
 The `container-scanning` accepts the following inputs:
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/dependency-risk-identification.mdx
+++ b/src/pages/other/gitlab-components/dependency-risk-identification.mdx
@@ -6,7 +6,7 @@ import { DependencyRiskIdentification } from '../../../components/texts/CICDJobs
 The `dependency-risk-identification` accepts the following inputs:
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/deploy.mdx
+++ b/src/pages/other/gitlab-components/deploy.mdx
@@ -6,7 +6,7 @@ The `deploy` accepts the following inputs:
 
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `runner_tags` | The runner tags used to select appropriate CI runners.   | No  | `""` |

--- a/src/pages/other/gitlab-components/full.mdx
+++ b/src/pages/other/gitlab-components/full.mdx
@@ -8,7 +8,7 @@ The `full-scan` workflow accepts the following inputs:
 
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `runner_tags` | The runner tags used to select appropriate CI runners.   | No  | `""` |

--- a/src/pages/other/gitlab-components/iac.mdx
+++ b/src/pages/other/gitlab-components/iac.mdx
@@ -5,7 +5,7 @@ import {IAC} from '../../../components/texts/CICDJobs'
   The `iac` accept a following inputs:
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/sast.mdx
+++ b/src/pages/other/gitlab-components/sast.mdx
@@ -6,7 +6,7 @@ import {SAST} from '../../../components/texts/CICDJobs'
 
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/sca.mdx
+++ b/src/pages/other/gitlab-components/sca.mdx
@@ -6,7 +6,7 @@ The `sca` accepts the following inputs:
 
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/secret-scanning.mdx
+++ b/src/pages/other/gitlab-components/secret-scanning.mdx
@@ -9,7 +9,7 @@ import {SecretScanning} from '../../../components/texts/CICDJobs'
  The `secret-scanning` accept a following inputs:
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `scan_stage`| The stage where the scan is run       | No       |     `test`     |

--- a/src/pages/other/gitlab-components/sign.mdx
+++ b/src/pages/other/gitlab-components/sign.mdx
@@ -5,7 +5,7 @@ import {Sign} from '../../../components/texts/CICDJobs'
 The `sign` accepts the following inputs:
 | Name        | Description                     | Required     | Default Value        |
 |-------------|---------------------------------|-------------|----------------------|
-| `api_url`   | The DevGuard API URL             | No           |       `https://api.main.devguard.org`     |
+| `api_url`   | The DevGuard API URL             | No           |       `https://api.devguard.org`     |
 | `asset_name`| Name of the asset to scan                    |      Yes  |      |
 | `token`     | API token for authenticating with DevGuard   |      Yes   |      |
 | `sign_stage`| The stage where the scan is run      | No       |     `deploy`     |


### PR DESCRIPTION
There are still some places left where api.main.devguard.org is used because I was not sure if those need to be changed as well.