### PR TITLE
Change DataGrip to BeeKeeper in Getting Started

### DIFF
--- a/src/pages/contributing/getting-started.mdx
+++ b/src/pages/contributing/getting-started.mdx
@@ -25,7 +25,7 @@ To set up and run DevGuard, ensure the following services are installed on your 
 - **[Git](https://git-scm.com/downloads)**: For cloning and managing repositories.  
 - **[Docker](https://docs.docker.com/desktop/)**: To run services in containers.  
 - **[Docker Compose](https://docs.docker.com/compose/install/)**: For orchestrating multi-container Docker applications.  
-- **[(DataGrip)](https://www.jetbrains.com/help/datagrip/installation-guide.html)**: For managing the database (or use any other database management tool of your choice).  
+- **[(BeeKeeper)](https://www.beekeeperstudio.io/get)**: For managing the database (or use any other database management tool of your choice).  
 - **[Go](https://go.dev/doc/install)**: Required to run the backend.  
 - **[Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)**: Required to run the frontend.  
 - **[Make](https://www.gnu.org/software/make/)**: To execute commands in the Makefile.  


### PR DESCRIPTION
As BeeKeeper is what we actually use, I changed the recommended but optional database tool to BeeKeeper and the URL to the BeeKeeper get page.