### PR TITLE
Added malicious packages reference page

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/pages/reference/vulnerability-database/malicious-packages.mdx
+++ b/src/pages/reference/vulnerability-database/malicious-packages.mdx
@@ -7,6 +7,23 @@ import {
 } from '@/components/ui/tooltip'
 import PageContentComingSoon from '@/components/PageContentComingSoon'
 
-# Malicious Packages
+# OSSF Malicious Packages
 
-<PageContentComingSoon />
+The OSSF Malicious Packages repository is an open-source database containing reports of malicious packages identified across different open-source package repositories. 
+
+## Scope 
+Instead of listing unintentional weaknesses like CVEs, malicious packages focus more on intentional malicious patterns like typosquatting attacks, account takeovers, dependency confusion, or manifest confusion, just to name a few. 
+
+
+The OSSF explicitly defines malicious packages as those that, when installed or used, compromise system confidentiality, availability, and/or integrity.
+
+## Data Access
+
+Malicious packages can be accessed via the public [GitHub repository](https://github.com/ossf/malicious-packages), located in the osv directory.
+Additionally, the OSSF publishes [up-to-date statistics](https://ossf.github.io/malicious-packages/stats/) on total malicious packages. 
+
+## Malicious Packages in DevGuard
+
+DevGuard will be using Malicious Packages in the upcoming purl inspector:
+
+<PageContentComingSoon/>


### PR DESCRIPTION
Added content to the malicious packages page under reference/vulnerability-database/malicious-packages.

The page focuses on explaining the concept of the malicious package project and differentiating it from other vulnerability databases.

The page is not yet completed since the use case of malicious packages in DevGuard is also not yet clear. 
Once it's clear we should finalize the section "Malicious Packages in DevGuard" with up-to-date information.