### PR TITLE
fix: fixed the table of vulndb for mobile

### DIFF
--- a/src/components/vulnerability-database/vulnerability-data-table/columns.tsx
+++ b/src/components/vulnerability-database/vulnerability-data-table/columns.tsx
@@ -17,10 +17,10 @@ export const columns: ColumnDef<Vulnerability>[] = [
     {
         accessorKey: 'cve',
         header: 'ID',
-        size: 150,
+        size: 200,
         cell: ({ row }) => (
             <Link href={`/vulnerability-database/${row.getValue('cve')}`}>
-                <div className="w-32">{row.getValue('cve')}</div>
+                {row.getValue('cve')}
             </Link>
         ),
     },
@@ -28,22 +28,25 @@ export const columns: ColumnDef<Vulnerability>[] = [
         accessorKey: 'description',
         header: 'Description',
         size: 600,
+        meta: {
+            className: 'hidden md:table-cell'
+        },
         cell: ({ row }) => {
             const description = row.getValue('description') as string
             const truncated =
                 description?.length > 100
                     ? description.substring(0, 100) + '...'
                     : description
-            return <div className="w-108">{truncated}</div>
+            return <span>{truncated}</span>
         },
     },
     {
         accessorKey: 'cvss',
-        size: 100,
+        size: 90,
         header: ({ column }) => {
             return (
                 <div
-                    className="flex cursor-pointer items-center hover:text-accent-foreground"
+                    className="flex cursor-pointer items-center hover:text-white/70"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -53,15 +56,18 @@ export const columns: ColumnDef<Vulnerability>[] = [
                 </div>
             )
         },
-        cell: ({ row }) => <div className="w-20">{row.getValue('cvss')}</div>,
+        cell: ({ row }) => <span>{row.getValue('cvss')}</span>,
     },
     {
         accessorKey: 'datePublished',
         size: 150,
+        meta: {
+            className: 'hidden md:table-cell'
+        },
         header: ({ column }) => {
             return (
                 <div
-                    className="flex cursor-pointer items-center hover:text-accent-foreground"
+                    className="flex cursor-pointer items-center hover:text-white/70"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -82,7 +88,7 @@ export const columns: ColumnDef<Vulnerability>[] = [
                     ? formatDistanceToNow(date, { addSuffix: true })
                     : format(date, 'd. MMM yy')
 
-            return <div className="w-32">{formatted}</div>
+            return <span>{formatted}</span>
         },
     },
 ]

--- a/src/components/vulnerability-database/vulnerability-data-table/data-table.tsx
+++ b/src/components/vulnerability-database/vulnerability-data-table/data-table.tsx
@@ -23,6 +23,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
 
 const PAGE_SIZE = 10
 
@@ -66,13 +67,17 @@ export function DataTable<TData, TValue>({
     return (
         <div>
             <div className="overflow-hidden rounded-md border">
-                <Table>
+                <Table className="table-fixed">
                     <TableHeader>
                         {table.getHeaderGroups().map((headerGroup) => (
                             <TableRow key={headerGroup.id}>
                                 {headerGroup.headers.map((header) => {
                                     return (
-                                        <TableHead key={header.id}>
+                                        <TableHead
+                                            key={header.id}
+                                            className={cn(header.column.columnDef.meta?.className)}
+                                            style={{ width: header.column.columnDef.size }}
+                                        >
                                             {header.isPlaceholder
                                                 ? null
                                                 : flexRender(
@@ -95,7 +100,10 @@ export function DataTable<TData, TValue>({
                                         {columns.map((column, cellIndex) => (
                                             <TableCell
                                                 key={`skeleton-cell-${cellIndex}`}
-                                                className="h-[75px] overflow-hidden"
+                                                className={cn(
+                                                    'h-[30px] md:h-[75px] overflow-hidden',
+                                                    column.meta?.className,
+                                                )}
                                                 style={{ width: column.size }}
                                             >
                                                 <Skeleton className="h-4 w-full" />
@@ -126,7 +134,11 @@ export function DataTable<TData, TValue>({
                                     {row.getVisibleCells().map((cell) => (
                                         <TableCell
                                             key={cell.id}
-                                            className="h-[75px] overflow-hidden"
+                                            className={cn(
+                                                "h-[30px] md:h-[75px] overflow-hidden",
+                                                cell.column.columnDef.meta?.className
+                                            )}
+                                            style={{ width: cell.column.columnDef.size }}
                                         >
                                             {flexRender(
                                                 cell.column.columnDef.cell,

--- a/src/types/tanstack-table.d.ts
+++ b/src/types/tanstack-table.d.ts
@@ -1,0 +1,7 @@
+import '@tanstack/react-table'
+
+declare module '@tanstack/react-table' {
+    interface ColumnMeta<TData extends RowData, TValue> {
+        className?: string
+    }
+}


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/1976

Removed unnecessary columns in mobile view because you can click on the cve to get all information. Now its responsive

<img width="387" height="160" alt="Bildschirmfoto 2026-05-26 um 15 52 45" src="https://github.com/user-attachments/assets/9fb04b66-69a0-4f70-9185-b5ff9ea84cc1" />
<img width="1179" height="352" alt="Bildschirmfoto 2026-05-26 um 15 52 42" src="https://github.com/user-attachments/assets/5773f57d-f232-4642-8a08-355ed62221ee" />
