### PR TITLE
Fix CTA link to docs

### DIFF
--- a/src/components/sections/Cta.tsx
+++ b/src/components/sections/Cta.tsx
@@ -15,7 +15,7 @@ export default function CTASection({
     primaryLabel = 'Get started for free',
     primaryHref = 'https://app.devguard.org',
     secondaryLabel = 'Read the docs',
-    secondaryHref = '/docs',
+    secondaryHref = '/',
 }: CTAProps) {
     return (
         <div className="relative isolate overflow-hidden py-24 sm:py-42">


### PR DESCRIPTION
`/docs` is not available, the main entrypoint is `/`.