### PR TITLE
fix: fixed chat icon from white to black

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -234,3 +234,7 @@ li>code,
 strong>code {
   @apply bg-black!;
 }
+
+.c7-bubble svg {
+  stroke: black;
+}


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/1952

<img width="80" height="71" alt="Bildschirmfoto 2026-06-10 um 09 25 39" src="https://github.com/user-attachments/assets/d48a0ca6-b3e8-43a5-9b4f-f4908379bec5" />
