### PR TITLE
Fix link/body text font-size mismatch by removing root font-size over…

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -34,7 +34,7 @@
 
 /* ─── 4. CSS variable overrides (unlayered — intentional DWT override) ── */
 :root {
-  font-size: 13.3333px;
+  /* font-size: 13.3333px; */
   --sidebar-background: var(--background);
 
   /* ── Typography (consumed by DWT theme-bridge) ── */


### PR DESCRIPTION
Fixes #2214 (partially)

Found and removed an unlayered `:root { font-size: 13.3333px; }` override in globals.css. This was causing all rem-based typography (including links using `.kern-link`) to render smaller than intended, since both links and body text share the same `--kern-typography-font-size-static-medium` CSS variable but were scaling inconsistently.

After this fix, link font-size and body text font-size are much closer (18px vs 18.08px, down from 15px vs 15.07px), though a small sub-pixel difference remains — likely from a separate nested em/rem calculation in the list rendering. Happy to investigate further if this isn't the full fix you were expecting..............