### PR TITLE
fix: chat widget is black again

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -12,9 +12,16 @@ export default function Document() {
             <Head>
                 {chatWidgetSrc && (
                     <script
+                        dangerouslySetInnerHTML={{
+                            __html: `Element.prototype.attachShadow=(f=>function(i){const r=f.call(this,{...i,mode:'open'});r.appendChild(document.createElement('style')).textContent='.c7-bubble svg{stroke:#1c1917!important}';return r})(Element.prototype.attachShadow)`,
+                        }}
+                    />
+                )}
+                {chatWidgetSrc && (
+                    <script
                         src={chatWidgetSrc}
                         data-library="/websites/devguard"
-                        async
+                        defer
                         {...(chatWidgetIntegrity && {
                             integrity: chatWidgetIntegrity,
                             crossOrigin: 'anonymous',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -253,10 +253,6 @@ strong>code {
   @apply bg-black!;
 }
 
-.c7-bubble svg {
-  stroke: black;
-}
-
 [data-kern-theme="dark"] .kern-table-responsive {
     --dwt-table-scroll-shadow: var(--input) !important;
 }


### PR DESCRIPTION
Not a pretty fix. The widget renders into a **closed** shadow root, so no stylesheet from the host
page can reach inside. I tried `globals.css` with `!important` and it stays white. Custom properties
do inherit through the boundary, but the bubble icon isn't themed through one: the widget hardcodes
`.c7-bubble svg { stroke: white; }`.

So the only option on our side is patching `attachShadow` to force the root open and inject an
override (the `async` → `defer` switch makes sure our patch runs first).

Proper fix belongs upstream: that `stroke: white` should be black, or driven by a custom property so
it can be themed from outside. Happy to drop this workaround once that exists.

<img width="91" height="83" alt="Bildschirmfoto 2026-08-20 um 10 43 43" src="https://github.com/user-attachments/assets/214827d3-b08d-46ca-b491-86cb31dc804f" />
